### PR TITLE
Animation additions part 1

### DIFF
--- a/Source/ART.Base.js
+++ b/Source/ART.Base.js
@@ -23,7 +23,10 @@ var VML = function(){
 };
 
 var MODE = SVG() ? 'SVG' : VML() ? 'VML' : null;
-if (!MODE) return;
+if (!MODE){
+    throw('no supported output mode!');
+    return;
+}
 
 ART.Shape = new Class({Extends: ART[MODE].Shape});
 ART.Group = new Class({Extends: ART[MODE].Group});

--- a/Source/ART.SVG.js
+++ b/Source/ART.SVG.js
@@ -36,8 +36,8 @@ ART.SVG = new Class({
 
 	resize: function(width, height){
 		var element = this.element;
-		element.setAttribute('width', width);
-		element.setAttribute('height', height);
+		if(!element.getStyle('width')) element.setStyle('width', width);
+		if(!element.getStyle('height')) element.setStyle('height', height);
 		this.width = width;
 		this.height = height;
 		return this;
@@ -217,12 +217,14 @@ ART.SVG.Base = new Class({
 		this[type + 'Brush'] = null;
 		var element = this.element;
 		if (color == null){
-			element.setAttribute(type, 'none');
-			element.removeAttribute(type + '-opacity');
+		    if(type != 'fill'){
+                //element.setStyle(type, 'none');
+                element.setStyle(type + '-opacity');
+			}
 		} else {
 			color = Color.detach(color);
-			element.setAttribute(type, color[0]);
-			element.setAttribute(type + '-opacity', color[1]);
+			element.setStyle(type, color[0]);
+			element.setStyle(type + '-opacity', color[1]);
 		}
 	},
 
@@ -291,8 +293,8 @@ ART.SVG.Base = new Class({
 
 		var image = createElement('image');
 		image.setAttributeNS(XLINK, 'href', url);
-		image.setAttribute('width', width);
-		image.setAttribute('height', height);
+		if(!image.getStyle('width')) image.setStyle('width', width);
+		if(!image.getStyle('height')) image.setStyle('height', height);
 		image.setAttribute('preserveAspectRatio', 'none'); // none, xMidYMid slice, xMidYMid meet
 
 		if (color1 != null){
@@ -338,8 +340,8 @@ ART.SVG.Base = new Class({
 		pattern.setAttribute('x', left || 0);
 		pattern.setAttribute('y', top || 0);
 		
-		pattern.setAttribute('width', width);
-		pattern.setAttribute('height', height);
+		if(!pattern.getStyle('width')) pattern.setStyle('width', width);
+		if(!pattern.getStyle('height')) pattern.setStyle('height', height);
 
 		//pattern.setAttribute('viewBox', '0 0 75 50');
 		//pattern.setAttribute('preserveAspectRatio', 'xMidYMid slice');
@@ -395,8 +397,8 @@ ART.SVG.Image = new Class({
 	draw: function(src, width, height){
 		var element = this.element;
 		element.setAttributeNS(XLINK, 'href', src);
-		element.setAttribute('width', width);
-		element.setAttribute('height', height);
+		if(!element.getStyle('width')) element.setStyle('width', width);
+		if(!element.getStyle('height')) element.setStyle('height', height);
 		this.width = width;
 		this.height = height;
 		return this;

--- a/Source/ART.js
+++ b/Source/ART.js
@@ -18,7 +18,7 @@ ART.Element = new Class({
 
 	/* dom */
 
-	inject: function(element){
+	inject: function(element, position){
 		if (element.element) element = element.element;
 		element.appendChild(this.element);
 		return this;
@@ -162,6 +162,14 @@ ART.Transform = new Class({
 		var flip = m.yx / m.xx > m.yy / m.xy ? -1 : 1;
 		if (m.xx < 0 ? m.xy >= 0 : m.xy < 0) flip = -flip;
 		return this.rotate(deg - Math.atan2(flip * m.yx, flip * m.xx) * 180 / Math.PI, x, y);
+	},
+	
+	centroidScaleTo: function(x, y){
+	    if(!y) y = x;
+	    var xx = this.xx;
+	    var yy = this.yy;
+	    this.scaleTo(x, y);
+	    this.move( (xx - this.xx) * this.width / 2 , (yy - this.yy) * this.height / 2 );
 	},
 
 	scaleTo: function(x, y){

--- a/Source/Fx.Step.js
+++ b/Source/Fx.Step.js
@@ -1,0 +1,199 @@
+/*
+---
+name: Fx.Step
+description: "It ♥s ART, over time"
+requires: [Fx, Fx/CSS, Color/Color, ART]
+provides: [Fx/Step]
+...
+*/
+
+(function(){
+
+this.Fx.Step = new Class({ // tweening for attrs & functions with support for macros and SVG paths
+        Extends: Fx,
+        initialize: function(element, options){
+            this.element = element;
+            this.parent(options);
+            if( (!this.options.attribute) && (!this.options.setter)) this.options.setter = 'centroidScaleTo';
+        },
+        set: function(now){
+            if(this.options.setter){
+                if(typeOf(this.options.setter) == 'function'){
+                    if(this.options.args){
+                        var argsv = [];
+                        now = this.serve(now);
+                        if(typeOf(now) == 'array' && now.length == 1) now = now[0];
+                        this.options.args.each(function(arg){
+                            argsv.push(now[arg]);
+                        }.bind(this));
+                        var context = this.options.bind?this.options.bind:this;
+                        this.options.setter.apply(context, argsv)
+                    }else{
+                        now = Math.floor(this.serve(now)*1000)/1000;
+                        this.options.setter(now);
+                    }
+                }else{
+                    if(this.options.args){
+                        var argsv = [];
+                        now = this.serve(now);
+                        this.options.args.each(function(arg){
+                            argsv[arg] = now[arg];
+                        }.bind(this));
+                        var context = this.options.bind?this.options.bind:this;
+                        if(this.element[this.options.setter]) this.element[this.options.setter].apply(context, argsv);
+                        else if(window[this.options.setter]) window[this.options.setter].apply(context, argsv);
+                    }else{
+                        now = Math.floor(this.serve(now)*1000)/1000;
+                        if(this.element[this.options.setter]) this.element[this.options.setter](now);
+                        else if(window[this.options.setter]) window[this.options.setter](now);
+                    }
+                }
+            }else{
+                if(this.options.attribute){
+                    this.element.setAttribute(this.options.attribute, this.serve(now));
+                }
+            }
+            return now;
+        },
+        serve: function(value, unit){
+            if (typeOf(value) != 'fx:step:value'){
+                if(typeOf(value) == 'array'){
+                    return value[0];
+                }else return value;
+            }
+            var returned = [];
+            value.each(function(bit){
+                returned = returned.concat(bit.parser.serve(bit.value, unit));
+            });
+            return returned;
+        },
+        parse: function(value){
+            value = Function.from(value)();
+            //this is a composite path do not rando tokenize
+            //todo: functions ex: transform
+            if(typeOf(value) == 'object' || value.test && value.test(/^([A-Za-z]( [0-9]+ [0-9]+){1,} ?){1,}$/g) ) value = [value];
+            else value = (typeof value == 'string') ? value.split(' ') : Array.from(value);
+            return value.map(function(val){
+                if(typeOf(val) != 'object') val = String(val);
+                else val = JSON.encode(val);
+                var found = false;
+                Object.each(Fx.Step.Parsers, function(parser, key){
+                    if (found) return;
+                    var parsed = parser.parse(val);
+                    if (parsed || parsed === 0) found = {value: parsed, parser: parser};
+                });
+                found = found || {value: val, parser: Fx.Step.Parsers.String};
+                return found;
+            });
+        },
+        render: function(){
+            
+        },
+        compute: function(from, to, delta){
+            from = this.parse(from);
+            to = this.parse(to);
+            if(typeOf(from) == 'array'){
+                var computed = [];
+                (Math.min(from.length, to.length)).times(function(i){
+                    computed.push({value: from[i].parser.compute(from[i].value, to[i].value, delta), parser: from[i].parser});
+                });
+                computed.$family = Function.from('fx:step:value');
+                return computed;
+            }else return this.parent(from, to, delta);
+        },
+    });
+    Fx.Step.Parsers = {
+        Color : Fx.CSS.Parsers.Color,
+        'Number' : Fx.CSS.Parsers.Number,
+        'Transform' : {
+            parse: function(value){
+                return false;
+            },
+            compute: function(zero, one){
+                return one;
+            },
+            serve: function(zero){
+                return zero;
+            }
+        },
+        'Object' : {
+            parse: function(value){
+                try{
+                    var data = JSON.decode(value);
+                    return data;
+                }catch(ex){
+                    return false;
+                }
+                //return typeOf(value) == 'object'?value:false;
+            },
+            compute: function(old_object, new_object, delta){
+                var results = {};
+                Object.each(old_object, function(value, key){
+                    if(new_object[key]) results[key] = Fx.compute(value, new_object[key], delta);
+                });
+                return results;
+            },
+            serve: function(value){
+                if(typeOf(value) == 'array' && value.length == 1) value = value[0];
+                return value;
+            }
+        },
+        'Path' : {
+            parse: function(value){
+                 var result = [];
+                 if(!value.test(/^([A-Za-z]( [0-9]+ [0-9]+){1,} ?){1,}$/g)) return false;
+                 var parts = value.split(/(?=[A-Za-z])/);
+                 parts.each(function(part){
+                    result.push(part.split(' '));
+                 });
+                 return (result.length == 0)?false:result;
+            },
+            compute: function(old_path, new_path, delta){
+                //console.log('compute', old_path, new_path, delta);
+                var new_path_item;
+                var path = [];
+                old_path.each(function(old_path_item, index){
+                    new_path_item = new_path[index];
+                    if(old_path_item[0] == new_path[index][0]){
+                        var path_node = [];
+                        path_node.push(old_path_item[0]);
+                        if(old_path_item.length >= 3){ //two args
+                            path_node.push(Math.floor(Fx.compute(Number.from(old_path_item[1]), Number.from(new_path_item[1]), delta)));
+                            path_node.push(Math.floor(Fx.compute(Number.from(old_path_item[2]), Number.from(new_path_item[2]), delta)));
+                        }
+                        if(old_path_item.length >= 5){ //four args
+                            path_node.push(Math.floor(Fx.compute(Number.from(old_path_item[3]), Number.from(new_path_item[3]), delta)));
+                            path_node.push(Math.floor(Fx.compute(Number.from(old_path_item[4]), Number.from(new_path_item[4]), delta)));
+                        }
+                        if(old_path_item.length >= 7){ //six args
+                            path_node.push(Math.floor(Fx.compute(Number.from(old_path_item[5]), Number.from(new_path_item[5]), delta)));
+                            path_node.push(Math.floor(Fx.compute(Number.from(old_path_item[6]), Number.from(new_path_item[6]), delta)));
+                        }
+                        path.push(path_node);
+                    }else{
+                        //transition from one line type to another
+                    }
+                });
+                return path;
+            },
+            serve: function(path){
+                var value = '';
+                path.map(function(node){
+                    value += node.join(' ');
+                });
+                return value;
+            },
+            diff : function(old_path, new_path){
+                
+            }
+        },
+        'String' : Fx.CSS.Parsers.String
+    }
+    Fx.Step.Parsers.String.serve = function(value){
+        if(typeOf(value) == 'array') return value[0];
+        else return value;
+    }
+    Fx.Step.Parsers.Color.serve = Fx.Step.Parsers.String.serve;
+    Fx.Step.Parsers.Number.serve = Fx.Step.Parsers.String.serve;
+})();
+


### PR DESCRIPTION
So currently there are a few additions, which allows for animation of paths and transformations for SVGs... it's not yet complete and there are a number of cases not supported:
- SVG segment type transforms (no tweening from an arc to a line on a path, for example)
- No segment additions, currently it doesn't support transforming to path with a different number of segments
- And worst of all, it currently directly tweens the SVG d attribute, when it should reach through the shape interface to alter the line.

In addition, I changed some of the places where it's setting attributes to setting styles, in the interest of external css being able to apply to these elements, I'm not sure if this will affect compatability... but if not, it's a worthwhile change.

regardless, it's pretty cool... I'm currently working inside some visualization code, but I'll loop back around and fill in some of these gaps in a couple of weeks... cheers!
